### PR TITLE
use field.databaseId instead of field.id due to breaking change from …

### DIFF
--- a/src/components/Name/query.js
+++ b/src/components/Name/query.js
@@ -2,7 +2,7 @@ import { conditionalLogicFragment } from "../../fragments";
 
 export const nameFieldFragment = /* GraphQL */ `
   ... on NameField {
-    id
+    id: databaseId
     adminLabel
     canPrepopulate
     conditionalLogic {

--- a/src/components/Section/query.js
+++ b/src/components/Section/query.js
@@ -2,7 +2,7 @@ import { conditionalLogicFragment } from "../../fragments";
 
 export const sectionFieldFragment = /* GraphQL */ `
 ... on SectionField {
-  id
+  id: databaseId
   cssClass
   databaseId
   label

--- a/src/container/FieldBuilder/index.js
+++ b/src/container/FieldBuilder/index.js
@@ -29,7 +29,7 @@ const FieldBuilder = ({
   return formFields.map((field) => {
     // Set the wrapper classes
     const {
-      id,
+      databaseId: id,
       captchaTheme,
       description,
       descriptionPlacement,

--- a/src/query.js
+++ b/src/query.js
@@ -51,7 +51,7 @@ export const gravityFormQuery = /* GraphQL */ `
       formFields {
         nodes {
           displayOnly
-          id
+          id: databaseId
           inputType
           layoutGridColumnSpan
           layoutSpacerGridColumnSpan


### PR DESCRIPTION
fixes https://github.com/robmarshall/next-gravity-forms/issues/37 due to an update from wp graphql gf in [version 0.13.0 ](https://github.com/AxeWP/wp-graphql-gravity-forms/releases/tag/v0.13.0)