### PR TITLE
Updated email regex to support non-standard TLDs

### DIFF
--- a/src/components/Email/index.js
+++ b/src/components/Email/index.js
@@ -56,7 +56,8 @@ const Email = ({ fieldData, name, labelFor, ...wrapProps }) => {
           {...register(name, {
             required: isRequired && (errorMessage || strings.errors.required),
             pattern: {
-              value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/,
+              value:
+                /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
               message: getFieldError(
                 { ...fieldData, inputMaskValue: true },
                 strings

--- a/tests/components/fields/Email.test.js
+++ b/tests/components/fields/Email.test.js
@@ -52,37 +52,48 @@ describe("Email field", () => {
     expect(element).toBeInTheDocument();
   });
 
-  it("submits form when value is correct", async () => {
-    const { container } = renderGravityForm({
-      data: {
-        gfForm: { formFields: { nodes: [field] } },
-      },
-    });
+  const emailCases = [
+    "test@test.com",
+    "test+plus@test.com",
+    "hello@my.kitchen",
+    "test@abc.de",
+    "test@business.online",
+    "test+test@example.info",
+  ];
 
-    fireEvent.input(screen.getByLabelText(/Email/i), {
-      target: {
-        value: "test@test.com",
-      },
-    });
-    await act(async () => {
-      fireEvent.submit(screen.getByRole("button"));
-    });
-
-    expect(submitGravityForm).toBeCalledWith({
-      id: mockFormData.gfForm.databaseId,
-      fieldValues: [
-        {
-          emailValues: {
-            value: "test@test.com",
-          },
-          id: field.id,
+  describe("submits form when value is correct", () => {
+    test.each(emailCases)("given %p", async (email) => {
+      const { container } = renderGravityForm({
+        data: {
+          gfForm: { formFields: { nodes: [field] } },
         },
-      ],
-    });
+      });
 
-    expect(
-      container.querySelector(`.gravityform__error_message`)
-    ).not.toBeInTheDocument();
+      fireEvent.input(screen.getByLabelText(/Email/i), {
+        target: {
+          value: email,
+        },
+      });
+      await act(async () => {
+        fireEvent.submit(screen.getByRole("button"));
+      });
+
+      expect(submitGravityForm).toBeCalledWith({
+        id: mockFormData.gfForm.databaseId,
+        fieldValues: [
+          {
+            emailValues: {
+              value: email,
+            },
+            id: field.id,
+          },
+        ],
+      });
+
+      expect(
+        container.querySelector(`.gravityform__error_message`)
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe("render errors", () => {
@@ -108,11 +119,27 @@ describe("Email field", () => {
 
       expect(submitGravityForm).not.toBeCalled();
     });
+  });
 
-    it("should display invalid email error when value is not valid", async () => {
+  const invalidEmails = ["test", "test@a.b"];
+
+  describe("should display invalid email error when value is not valid", () => {
+    let container;
+    let element;
+    beforeEach(() => {
+      const rendered = renderGravityForm({
+        data: {
+          gfForm: { formFields: { nodes: [field] } },
+        },
+      });
+      container = rendered.container;
+
+      element = container.querySelector(`#${fieldId}`);
+    });
+    test.each(invalidEmails)("given %p", async (email) => {
       fireEvent.input(screen.getByLabelText(/Email/i), {
         target: {
-          value: "test",
+          value: email,
         },
       });
 
@@ -126,8 +153,6 @@ describe("Email field", () => {
 
       expect(submitGravityForm).not.toBeCalled();
     });
-
-    // it("should display error when confirmation email is set and emails don't match", async () => {});
   });
 
   // renders confirmation email


### PR DESCRIPTION
I noticed that the default regex pattern doesn't support non-common TLDs e.g. `.kitchen` or `.online`.

This PR updates the regex to use the one from [emailregex.com](https://emailregex.com) and adds tests.