### PR TITLE
docs: add instructions to support multipart/form-data content type

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,20 @@ To enable file uploading functionality, your GraphQL server must support the `Up
 
 If you attempt to add a file upload field to your form without support for the `Upload` scalar type, your API will return an error. Ensure that your GraphQL server is properly configured to handle file uploads by integrating the WP GraphQL Upload plugin or another equivalent solution that provides support for the `Upload` type.
 
+If using the [WP GraphQL Upload](https://github.com/dre1080/wp-graphql-upload) plugin, the following filter also needs to be added to allow the `multipart/form-data` content type.
+
+```
+add_filter( 'graphql_is_valid_http_content_type', function( $is_valid, $content_type ) {
+
+  if ( 0 === stripos( $content_type, 'multipart/form-data' ) ) {
+    return true;
+  }
+
+  return $is_valid;
+
+}, 10, 2 );
+```
+
 When enabling the `Enable Multi-File Upload` option, it's important to note that files are not uploaded immediately upon being dropped into the upload area. Instead, all files are uploaded together during the form submission process. However, be aware that this can introduce a delay, particularly when users upload large files. Might be good to show spinner while uploading.
 
 ## Date field


### PR DESCRIPTION
The [WPGraphQL Upload](https://github.com/dre1080/wp-graphql-upload) plugin doesn't work with version 2 of [WPGraphQL](https://github.com/wp-graphql/wp-graphql).

https://github.com/dre1080/wp-graphql-upload/issues/17#issuecomment-2695956712

This PR adds the currently required workaround to the documentation.