### PR TITLE
Add MultiChoiceField support

### DIFF
--- a/src/components/SelectorList/query.js
+++ b/src/components/SelectorList/query.js
@@ -36,6 +36,33 @@ export const checkboxFieldFragment = /* GraphQL */ `
   }
 `;
 
+export const multiChoiceFieldFragment = /* GraphQL */ `
+  ... on MultiChoiceField {
+    canPrepopulate
+    choices {
+      ... on MultiChoiceFieldChoice {
+        isSelected
+        text
+        value
+      }
+    }
+    conditionalLogic {
+      ${conditionalLogicFragment}
+    }
+    cssClass
+    description
+    descriptionPlacement
+    errorMessage
+    hasChoiceValue
+    inputName
+    inputType
+    isRequired
+    label
+    labelPlacement
+    value
+  }
+`;
+
 export const radioFieldFragment = /* GraphQL */ `
   ... on RadioField {
     canPrepopulate

--- a/src/container/FieldBuilder/index.js
+++ b/src/container/FieldBuilder/index.js
@@ -169,7 +169,18 @@ const FieldBuilder = ({
         return <Select key={id} {...props} />;
       case "RADIO":
       case "CHECKBOX":
-        return <SelectorList key={id} {...props} />;
+      case "MULTI_CHOICE":
+        return (
+          <SelectorList
+            key={id}
+            {...props}
+            fieldData={
+              type === "MULTI_CHOICE"
+                ? { ...fieldData, type: fieldData.inputType }
+                : fieldData
+            }
+          />
+        );
       case "SECTION":
         return <Section key={id} {...props} />;
       case "HONEYPOT":

--- a/src/query.js
+++ b/src/query.js
@@ -14,6 +14,7 @@ import { numberFieldFragment } from "./components/Number/query";
 import {
   radioFieldFragment,
   checkboxFieldFragment,
+  multiChoiceFieldFragment,
 } from "./components/SelectorList/query";
 import { consentFieldFragment } from "./components/Consent/query";
 import { timeFieldFragment } from "./components/Time/query";
@@ -80,6 +81,7 @@ export const gravityFormQuery = /* GraphQL */ `
           ${numberFieldFragment}
           ${phoneFieldFragment}
           ${radioFieldFragment}
+          ${multiChoiceFieldFragment}
           ${selectFieldFragment}
           ${multiSelectFieldFragment}
           ${textareaFieldFragment}


### PR DESCRIPTION
Adds support for Gravity Forms `MultiChoiceField`.

`MultiChoiceField` is returned by WPGraphQL for Gravity Forms as `type: "MULTI_CHOICE"` with an `inputType` of either `RADIO` or `CHECKBOX`.

Before this change, the query did not fetch MultiChoiceField-specific data such as `label` and `choices`, and `FieldBuilder` did not handle `MULTI_CHOICE`, causing the field to render as `null`.

Changes:
- Adds a `multiChoiceFieldFragment`.
- Includes the fragment in the main `gravityFormQuery`.
- Renders `MULTI_CHOICE` fields through the existing `SelectorList`.
- Uses `inputType` to render the field as radio or checkbox.

Tested:
- `npm run build` completed successfully.
- Build completed with existing Rollup external dependency warnings.