### PR TITLE
Remove size field from TextArea since it's removed in GF 3

### DIFF
--- a/src/components/Textarea/index.js
+++ b/src/components/Textarea/index.js
@@ -17,7 +17,6 @@ const Textarea = ({ fieldData, name, labelFor, wrapClassName, wrapId }) => {
     isRequired,
     maxLength,
     placeholder,
-    size,
     type: typeUpper,
   } = fieldData;
 
@@ -41,7 +40,7 @@ const Textarea = ({ fieldData, name, labelFor, wrapClassName, wrapId }) => {
       <textarea
         aria-invalid={Boolean(errors?.[name])}
         aria-required={isRequired}
-        className={classnames(cssClass, valueToLowerCase(size), "textarea")}
+        className={classnames(cssClass, "textarea")}
         id={labelFor}
         maxLength={maxLength > 0 ? maxLength : undefined}
         name={name}

--- a/src/components/Textarea/query.js
+++ b/src/components/Textarea/query.js
@@ -17,7 +17,6 @@ export const textareaFieldFragment = /* GraphQL */ `
     maxLength
     shouldAllowDuplicates
     placeholder
-    size
     hasRichTextEditor
     value
   }


### PR DESCRIPTION
Gravity Forms 3 removes the size option from the textarea field, so the main query results in a GraphQL error.